### PR TITLE
Replace MW aggregator with server classes

### DIFF
--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/agents/scheduler/DummyAgent.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/agents/scheduler/DummyAgent.sarl
@@ -24,15 +24,15 @@ import java.util.Random
 import io.sarl.core.DefaultContextInteractions
 import io.sarl.core.Initialize
 
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_AgentPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.EntityPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.FacilitySensedPercept
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.GotoFacility
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.TeamMemberPercept
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.capacities.C_Reporting
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.skills.S_ConsoleReporting
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ContinueOnRoute
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ChargingStationSensedPercept
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TellEntityInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TellPlayerTeamInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_FacilityInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_ChargingStationInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_AgentInfo
 
 /** 
  * @author keiran
@@ -65,13 +65,13 @@ agent DummyAgent {
      * agents names the agent will store the percepts and then call selectAction to 
      * decide which action to emit based on the information it has about the world.
      */
-    on EntityPercept {
+    on E_TellEntityInfo {
     	// Code to react to entities.
 	}
 
 	// This will be fired for every facility observed
 	// Observe the same event will be received (and acted upon) by each dummy agent
-	on FacilitySensedPercept {
+	on E_FacilityInfo {
     	// Build an internal list of facilities
     	if (!facilities.contains(occurrence.facility.name)) {
     		facilities.add(occurrence.facility.name)
@@ -80,13 +80,13 @@ agent DummyAgent {
 
 	// This will be fired for every charging station seen	
 	// Observe the same event will be received (and acted upon) by each dummy agent
-	on ChargingStationSensedPercept {
+	on E_ChargingStationInfo {
 	}
 	
 	
 
 	//	Follow some route to some random place
-    on TeamMemberPercept [occurrence.PlayerState.name == this.playerName && facilities.length > 0] { 
+    on E_TellPlayerTeamInfo [occurrence.PlayerState.name == this.playerName && facilities.length > 0] { 
     	// Randomly select a facility (if there is one!) and visit it.
     	// This event will be handled by coordinator who will send it to EIS for execution
 	

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/agents/scheduler/SchedulerAgent.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/agents/scheduler/SchedulerAgent.sarl
@@ -45,10 +45,6 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.capacities.C_MassimTalking
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.skills.S_ConsoleReporting
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.skills.S_MassimTalking
 
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.EntityPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.FacilitySensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.JobPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.WorkshopSensedPercept
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_AgentAction
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_SenseEnvironment
 
@@ -62,7 +58,10 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.utils.ConfHandler
 
 
 import eis.exceptions.PerceiveException
-
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TellEntityInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_FacilityInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_WorkshopInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_JobInfo
 
 /** 
  * @author Sebastian Sardina (ssardina@gmail.com)
@@ -241,11 +240,11 @@ agent SchedulerAgent {
 					aggregator.addActionResults(playerName, percepts)
 					
 					var PlayerState = PlayerStateBuilder.build(myServerName, percepts) // build a new agent state from percept
-					aggregator.addTeamMember(playerName, PlayerState) // Fill the aggregator with this agent state for playerName
+					aggregator.addPlayerTeam(playerName, PlayerState) // Fill the aggregator with this agent state for playerName
 					
 					// OTHER ENTITIES: 
                     //	Add to aggregator the info of all other entities that are not part of the team (not agents)
-                    aggregator.addEntities()
+                    aggregator.addPlayerOpposition()
 
 					// FACILITIES: Aggregate all facilities information 
 					// (shop, workshops, charging stations, dump, storage, resourceNodes)
@@ -293,7 +292,7 @@ agent SchedulerAgent {
 
 
 		// Emit SARL events for each TEAM percept (now just the money)
-		var allEntityPercepts = new HashSet<EntityPercept>()
+		var allEntityPercepts = new HashSet<E_TellEntityInfo>()
 		allEntityPercepts.addAll(aggregator.getTeamMemberPercepts())
 		allEntityPercepts.addAll(aggregator.getGameEntityPercepts())
 		agent_says("Emitting {0} event percepts about {1}", allEntityPercepts.length, "ENTITIES")
@@ -309,7 +308,7 @@ agent SchedulerAgent {
 		}
 
 		// Emit SARL events for all perception about FACILITIES (shops, charging stations, workshops, dumps, storage, resources)
-		var allFacilityPercepts = new ArrayList<FacilitySensedPercept>()
+		var allFacilityPercepts = new ArrayList<E_FacilityInfo>()
 		allFacilityPercepts.addAll(aggregator.shopSensedPercepts)
 		allFacilityPercepts.addAll(aggregator.chargingStationSensedPercepts)
 		allFacilityPercepts.addAll(aggregator.workshopSensedPercepts)
@@ -322,7 +321,7 @@ agent SchedulerAgent {
 		}
 
 		// Emit SARL events for all perception about JOBS (regular, auctions, team jobs, missions)
-		var allJobPercepts = new ArrayList<JobPercept>()
+		var allJobPercepts = new ArrayList<E_JobInfo>()
 		allJobPercepts.addAll(aggregator.regularJobPercepts)
 		allJobPercepts.addAll(aggregator.teamJobPercepts)
 		allJobPercepts.addAll(aggregator.auctionJobPercepts)
@@ -364,7 +363,7 @@ agent SchedulerAgent {
 		}
 	}
 
-	on WorkshopSensedPercept {
+	on E_WorkshopInfo {
 		agent_says("I have seen a workshop named {0}", occurrence.workshop.name)
 	}
 

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/AgentStateBuilder.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/AgentStateBuilder.sarl
@@ -25,7 +25,7 @@ import java.util.Collection
 import java.util.HashMap
 
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Position
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
 
 /** 
  * @author boblo
@@ -40,9 +40,9 @@ class PlayerStateBuilder {
 	/**
 	 * build Builds a PlayerState and aggregates all the percepts together.
 	 * @param name - the name of the agent that received all the percepts. This function will build a PlayerState for the agent that received the percepts.
-	 * @param percepts - the colllection of percepts that was received.
+	 * @param percepts - the collection of percepts that was received.
 	 */
-    public static def build(name : String, percepts : Collection<Percept>) : PlayerState {
+    public static def build(name : String, percepts : Collection<Percept>) : TeamEntityAgent {
 
 		var gameEntity = EntityBuffer.get(name)
 		var agentName = name // name of the agent
@@ -92,7 +92,7 @@ class PlayerStateBuilder {
             }
         }
 
-        return new PlayerState(
+        return new TeamEntityAgent(
         	agentName,
 			role, 
 			team, 

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/EntityBuffer.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/EntityBuffer.sarl
@@ -19,15 +19,16 @@
 package au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator
 
 import eis.iilang.Percept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.GameEntity
 import java.util.Collection
 import java.util.HashMap
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.EntityAgent
+
 /** 
  * Class to hold entity listings so they can be looked up by name
  * @param entities HASHMAP class used to keep track of entities.
  */
 class EntityBuffer {
-    public static var entities : HashMap<String, GameEntity>
+    public static var entities : HashMap<String, EntityAgent>
 
     public static def init() {
         entities = new HashMap();
@@ -46,11 +47,11 @@ class EntityBuffer {
                 var lon = Util.extractDouble(p.parameters.get(3));
                 var role = Util.extractString(p.parameters.get(4));
 
-                var ge : GameEntity
+                var ge : EntityAgent
                 if (entities.containsKey(name)) {
                     ge = entities.get(name);
                 } else {
-                    ge = new GameEntity(name,role,team,lat,lon)
+                    ge = new EntityAgent(name,role,team,lat,lon)
                 }
                 entities.put(name, ge)	// push the game entity for entity with name 
             }
@@ -61,7 +62,7 @@ class EntityBuffer {
 	 * get, gets a perticular entity by it's identifier (name).
 	 * @param name String identifying the entity.
 	 */
-    public static def get(name : String) : GameEntity {
+    public static def get(name : String) : EntityAgent {
         return entities.get(name);
     }
 

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/PerceptAggregator.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/PerceptAggregator.sarl
@@ -19,71 +19,73 @@
 package au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator
 
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ActionResult
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.GameEntity
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Shop
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Workshop
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.EntityPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.TeamMemberPercept
-import java.util.ArrayList
-import java.util.HashMap
-import java.util.HashSet
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.AuctionJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ChargingStation
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.CityDataCreator
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Dump
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.MissionJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.RegularJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Resource
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Shop
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Storage
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ItemBundle
-import java.util.Collection
-import eis.iilang.Percept
-import eis.iilang.Function
-import eis.iilang.ParameterList
-
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ShopItem
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.StorageItem
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ItemContainer
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Item
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamJob
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.MissionJob
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ActionStatusPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ShopSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ChargingStationSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.DumpSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.StorageSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.ResourceSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.RegularJobPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.AuctionJobPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.TeamJobPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.MissionJobPercept
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Workshop
+import eis.iilang.Percept
+import java.util.ArrayList
+import java.util.Collection
+import java.util.HashMap
+import java.util.HashSet
 import java.util.List
 import java.util.Set
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.WorkshopSensedPercept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.CityDataCreator
 import massim.protocol.scenario.city.data.FacilityData
 import massim.protocol.scenario.city.data.JobData
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TellEntityInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TellPlayerTeamInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.EntityAgent
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_ShopInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_WorkshopInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_DumpInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_StorageInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_ChargingStationInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_ActionStatusInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_ResourceInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_AuctionJobInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_MissionJobInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_TeamJobInfo
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.E_RegularJobInfo
 
 /** 
  * @author boblo
- * Class used to collect all of the percepts from all of the agents in MASSIM to minimise event emission.
+ * 
+ * Class used to collect all of the percepts from all of the agents in MASSIM to minimize event emission.
  */
 class PerceptAggregator {
+
+	/*
+	 * These data structures keep track of all the information known so far from the game, as received
+	 * from all agent players in the team
+	 * 
+	 * The are all hash maps mapping the name id to an object storing the corresponding information
+	 */
+	var players_team : HashMap<String, TeamEntityAgent>
+	var players_opp : HashMap<String, EntityAgent>
 
 	var actionResults : HashMap<String, ActionResult>
 	var auctionJobs : HashMap<String, AuctionJob>
 	var missionJobs : HashMap<String, MissionJob>
-	public var chargingStations : HashMap<String, ChargingStation>
-	var dumps : HashMap<String, Dump>
-	var jobs : HashMap<String, JobData>
 	var regularJobs : HashMap<String, RegularJob>
+	var jobs : HashMap<String, JobData>
 	var teamJobs : HashMap<String, TeamJob>
+
 	var facilities : HashMap<String, FacilityData>
-	var resources : HashMap<String, Resource>
+	var chargingStations : HashMap<String, ChargingStation>
+	var dumps : HashMap<String, Dump>
 	var shops : HashMap<String, Shop>
 	var storages : HashMap<String, Storage>
-	var PlayerStates : HashMap<String, PlayerState>
 	var workshops : HashMap<String, Workshop>
-	var entities : HashMap<String, GameEntity>
+
+	var resources : HashMap<String, Resource>
 	var money : double
 	
 	/**
@@ -100,9 +102,9 @@ class PerceptAggregator {
 		this.resources = new HashMap();
 		this.shops = new HashMap();
 		this.storages = new HashMap();
-		this.PlayerStates = new HashMap();
+		this.players_team = new HashMap();
 		this.workshops = new HashMap();
-		this.entities = new HashMap();
+		this.players_opp = new HashMap();
 		this.money = 0;
 	}
 	
@@ -110,42 +112,64 @@ class PerceptAggregator {
 	
 	
 	/**
-	 * Function used to add the information relating to team members to the team member hashmap.
+	 * Add the information relating to team members to the this.players_team HashMap.
+	 * 
 	 * @param source - list of agents that received this percept from MASSIM. 
 	 * @param PlayerState - the observed entity
 	 */
-	public def addTeamMember(source : String, PlayerState : PlayerState) {
-		PlayerStates.put(source, PlayerState)
+	public def addPlayerTeam(source : String, teamEntity : TeamEntityAgent) {
+		players_team.put(source, teamEntity)
 	}
 
-	/**
-	 * Function used to populate the Entity HashMap
-	 * automatically gets the entities from the EntityBuffer
+	/** 
+	 * Add the information relating to opposition team to the this.players_opp HashMap.
+	 * 
+	 * @param source - list of agents that received this percept from MASSIM. 
+	 * @param PlayerState - the observed entity
 	 */
-	public def addEntities() {
+	public def addPlayerOpposition(source : String, entityAgent : EntityAgent) {
+		players_opp.put(source, entityAgent)
+	}
+
+
+	/** 
+	 * Add the information relating to all opposition agents from EntityBuffer
+	 * 
+	 */
+	 // TODO: can we get rid of this? Do we need EntityBuffer complex data?
+	public def addPlayerOpposition() {
 		for (e : EntityBuffer.entities.keySet) {
-			if (!this.PlayerStates.keySet.contains(e)) { // add only if they are not agents of the team
-				this.entities.put(e, (EntityBuffer.entities.get(e)))
+			if (!this.players_team.keySet.contains(e)) { // add only if they are not agents of the team
+				addPlayerOpposition(e, (EntityBuffer.entities.get(e)))
 			}
 		}
 	}
 
 	/**
-	 * Function used to add the current amount of Money the team has.
-	 * @param money, double the amount of money perceived our team to have.
+	 * Store the amount of money the team has.
+	 * 
+	 * @param money - the amount of money perceived our team to have.
 	 */
 	public def addMoneyPercept(money : double) {
 		this.money = money
 	}
 	
 	/**
-	 * Parse all of the percepts and populate the facilities hashmap with all facilities.
+	 * Populate the this.facilities HashMap with all info coming from the percept about facilities
+	 * 
 	 * @param percepts - the collection of percepts received from MASSIM
+	 * 
 	 */
 	public def addFacilities(percepts : Collection<Percept>) {
-		percepts.stream().filter([ p : Percept |
+		
+		// extract percepts that are about facilities
+		val stream_facilities = percepts.stream().filter([ p : Percept |
 			CityDataCreator.FACILITY_TYPES.contains(p.name)
-		]).map([ p : Percept |
+		])
+		
+		// for each facility percept, create a corresponding facility object (class provided by game server)
+		// and add that object to this.facilities
+		stream_facilities.map([ p : Percept |
 			val facility = CityDataCreator.createFacility(p)
 			this.facilities.put(facility.name, facility)
 		]);
@@ -153,8 +177,9 @@ class PerceptAggregator {
 
 
 	/**
-	 * Parse all of the percepts and populate the jobs hashmap with all jobs (including Auction and Mission).
-	 * @param percepts - the collection of jobs
+	 * Populate the this.jobs HashMap with all info coming from the percept about jobs
+	 * 
+	 * @param percepts - the collection of percepts received from MASSIM
 	 */	
 	public def addJobs(percepts : Collection<Percept>) {
 		percepts.stream().filter([ p : Percept |
@@ -165,16 +190,18 @@ class PerceptAggregator {
 		]);
 	}
 	
+	
+	
 	/**
-	 * Function to get the action results of each agent. 
-	 * #param source - The source of the percept is refering to. 
-	 * @percepts - the collection of percepts from MASSIM for the source agent. 
+	 * Get the action results for an agent sources. 
+	 * 
+	 * @param source - the EI source (e.g., player_connectionA1) of the percept is referring to. 
+	 * @param percepts - the collection of percepts received from MASSIM
 	 */
 	public def addActionResults(source : String, percepts : Collection<Percept>){
 		
 		var action : String
 		var success : String
-		
 		
 		for(p : percepts){
 			switch(p.name){
@@ -186,53 +213,100 @@ class PerceptAggregator {
 				}
 			}
 		}
-		
 		this.actionResults.put(source, new ActionResult(action, success))
-		
 	}
 	
-	/**
-	 * Function called by the communicator to get all Team Member events
-	 * @return an set of events containing teamMemberpercepts
-	 */
-	public def getTeamMemberPercepts() : Set<EntityPercept> {
-		var events = new HashSet<EntityPercept>()
+	
+	
+	
+	
+	
+	
+	
+	///////////////////////////////////////////////////////////////////////////////
+	//	GETTERS
+	// /////////////////////////////////////////////////////////////////////////////
 
-		for (agentName : PlayerStates.keySet) {
+	/*
+	 * Methods to extract individual information from percepts
+	 */
+
+	/** 
+	 * Get the set of shop names
+	 * 
+	 * @returns the set of names of known shops
+	 */
+	public def getShopsNames() : Set<String> {
+		return shops.keySet()
+	}
+
+	/** 
+	 * Get the set of facilitiesnames
+	 * 
+	 * @returns the set of names of known facilities
+	 */
+	public def getFacilitiesNames() : Set<String> {
+		return facilities.keySet()
+	}
+
+
+
+
+
+
+	///////////////////////////////////////////////////////////////////////////////
+	//	EVENT CREATION FROM DATA
+	// /////////////////////////////////////////////////////////////////////////////
+	
+	
+	/** 
+	 * Build a set E_TellPlayerTeamInfo events
+	 * 		To send information about team members
+	 * 
+	 * @return an set of E_TellPlayerTeamInfo events containing the data for each player team-mate
+	 */
+	public def getTeamMemberPercepts() : Set<E_TellEntityInfo> {
+		var events = new HashSet<E_TellEntityInfo>()
+
+		for (agentName : players_team.keySet) {
 			var sources = new HashSet<String>()
 			sources.add(agentName)
-			events.add(new TeamMemberPercept(sources, PlayerStates.get(agentName)))
+			events.add(new E_TellPlayerTeamInfo(sources, players_team.get(agentName)))
 		}
 		return events
 	}
 
-	/**
-	 * Function called by the communicator to get all entity events.
-	 * @return an set of events containing observed entities.
+	/** 
+	 * Build a set E_TellEntityInfoevents
+	 * 		To send information about opposition entities
+	 * 
+	 * @return an set of E_TellEntityInfo events 
 	 */
-	public def getGameEntityPercepts() : Set<EntityPercept> {
-		var events = new HashSet<EntityPercept>()
+	public def getGameEntityPercepts() : Set<E_TellEntityInfo> {
+		var events = new HashSet<E_TellEntityInfo>()
 
-		for (entityName : entities.keySet) {
-			var ep = new EntityPercept(PlayerStates.keySet, entities.get(entityName))
+		for (entityName : players_opp.keySet) {
+			var ep = new E_TellEntityInfo(players_team.keySet, players_opp.get(entityName))
 			events.add(ep);
 		}
 		return events
 
 	}
-	
-	/**
-	 * Function use to get all of the percepts relating friendly entity actions.
-	 * @return ArrayList of events each containing an action status and the source agent its from.
+
+	/** 
+	 * Build a set E_ActionStatusInfo
+	 * 	To send information about all action result from team members
+	 * 
+	 * @return an set of E_ActionStatusInfo events 
 	 */
-	public def getActionPercepts() : List<ActionStatusPercept>{
-		var events = new ArrayList<ActionStatusPercept>
+	public def getActionPercepts() : List<E_ActionStatusInfo>{
+		var events = new ArrayList<E_ActionStatusInfo>
 		
 		for (agentName : actionResults.keySet){
 			var nameSet = new HashSet<String>()
 			nameSet.add(agentName)
 			
-			var ap = new ActionStatusPercept(nameSet, actionResults.get(agentName))
+			var ap = new E_ActionStatusInfo(nameSet, actionResults.get(agentName))
 			events.add(ap)
 		}
 		return events
@@ -252,117 +326,118 @@ class PerceptAggregator {
 	 * https://github.com/agentcontest/massim/blob/massim-2017-1.7/docs/scenario.md#facilities
 	 */
 
+
+
 	/** 
-	 * Function used to get all Shops
-	 * @return a list of events containing shops.
+	 * Build a set E_ShopInfo
+	 * To send information about all shops known
+	 * 
+	 * @return an set of E_ShopInfo events 
 	 */
-	public def getShopSensedPercepts() : List<ShopSensedPercept> {
-		var events = new ArrayList<ShopSensedPercept>
+	public def getShopSensedPercepts() : List<E_ShopInfo> {
+		var events = new ArrayList<E_ShopInfo>
 
 		for (facilityname : shops.keySet) {
-			var ssp = new ShopSensedPercept(PlayerStates.keySet, shops.get(facilityname));
+			var ssp = new E_ShopInfo(players_team.keySet, shops.get(facilityname));
 			events.add(ssp)
 		}
 		return events
 	}
-	
-	
-	/**
-	 * Function used to get all charging stations.
-	 * @returns a list of events containing charging stations.
+
+	/** 
+	 * Build a set E_ChargingStationInfo
+	 * To send information about all charging stations known
+	 * 
+	 * @return an set of E_ChargingStationInfo events 
 	 */
-	public def getChargingStationSensedPercepts() : List<ChargingStationSensedPercept>{
-		var events = new ArrayList<ChargingStationSensedPercept>
+	public def getChargingStationSensedPercepts() : List<E_ChargingStationInfo>{
+		var events = new ArrayList<E_ChargingStationInfo>
 		
 		for (stationName : chargingStations.keySet){
-			var cssp = new ChargingStationSensedPercept(PlayerStates.keySet, chargingStations.get(stationName));
+			var cssp = new E_ChargingStationInfo(players_team.keySet, chargingStations.get(stationName));
 			events.add(cssp)
 		}
 		return events
 	}
 
 	/** 
-	 * Function used to get all Workshops
-	 * @return a list of events containing workshops.
+	 * Build a set E_WorkshopInfo
+	 * To send information about all workshops known
+	 * 
+	 * @return an set of E_WorkshopInfo events 
 	 */
-	public def getWorkshopSensedPercepts() : List<WorkshopSensedPercept> {
-		var events = new ArrayList<WorkshopSensedPercept>
+	public def getWorkshopSensedPercepts() : List<E_WorkshopInfo> {
+		var events = new ArrayList<E_WorkshopInfo>
 
 		for (facilityname : workshops.keySet) {
-			var ssp = new WorkshopSensedPercept(PlayerStates.keySet, workshops.get(facilityname));
+			var ssp = new E_WorkshopInfo(players_team.keySet, workshops.get(facilityname));
 			events.add(ssp)
 		}
 		return events
 	}
 
-
-	
-	/**
-	 * Function used to get all Dumps
-	 * @returns a list of events containing dumps
+	/** 
+	 * Build a set E_DumpInfo
+	 * To send information about all dumps known
+	 * 
+	 * @return an set of E_DumpInfo events 
 	 */
-	public def getDumpSensedPercepts() : List<DumpSensedPercept>{
+	public def getDumpSensedPercepts() : List<E_DumpInfo>{
 
-		var events = new ArrayList<DumpSensedPercept>
+		var events = new ArrayList<E_DumpInfo>
 
 		for (facilityname : dumps.keySet) {
-			var dsp = new DumpSensedPercept(PlayerStates.keySet, dumps.get(facilityname));
+			var dsp = new E_DumpInfo(players_team.keySet, dumps.get(facilityname));
 			events.add(dsp)
 		}
 		return events
 	}
-	
 
-	/**
-	 * Function used to get all storages
-	 * @returns a list of events containing storages
+	/** 
+	 * Build a set E_StorageInfo
+	 * To send information about all storage known
+	 * 
+	 * @return an set of E_StorageInfo events 
 	 */
-	public def getStorageSensedPercepts() : List<StorageSensedPercept> {
-		var events = new ArrayList<StorageSensedPercept>
+	public def getStorageSensedPercepts() : List<E_StorageInfo> {
+		var events = new ArrayList<E_StorageInfo>
 
 		for (facilityname : storages.keySet) {
-			var ssp = new StorageSensedPercept(PlayerStates.keySet, storages.get(facilityname));
+			var ssp = new E_StorageInfo(players_team.keySet, storages.get(facilityname));
 			events.add(ssp)
 		}
 		return events 
 	}
 
-	
-	/**
-	 * Function used to get all Resources
-	 * @returns a list of events containing resources
+	/** 
+	 * Build a set E_ResourceInfo
+	 * To send information about all resources known
+	 * 
+	 * @return an set of E_ResourceInfo events 
 	 */
-	public def getResourceSensedPercepts() : List<ResourceSensedPercept> { 
-		var events = new ArrayList<ResourceSensedPercept>
+	public def getResourceSensedPercepts() : List<E_ResourceInfo> { 
+		var events = new ArrayList<E_ResourceInfo>
 
 		for (resourceName : resources.keySet) {
-			var rsp = new ResourceSensedPercept(PlayerStates.keySet, resources.get(resourceName));
+			var rsp = new E_ResourceInfo(players_team.keySet, resources.get(resourceName));
 			events.add(rsp)
 		}
 		return events 
 	}
 	
 	
-	
-	/**
-	 * GET functions for JOBS:
-	 * https://github.com/agentcontest/massim/blob/massim-2017-1.7/docs/scenario.md#job
-	 * 
-	 *  regular jobs
-	 *  auction jobs
-	 *  mission (mandatory job or fine!)
-	 *  
-	 */
 
-	/**
-	 * Function used to get all Auction Jobs
-	 * @returns a list of events each containing an auction event.
+	/** 
+	 * Build a set E_ResourceInfo
+	 * To send information about all resources known
+	 * 
+	 * @return an set of E_ResourceInfo events 
 	 */
-	public def getAuctionJobPercepts() : List<AuctionJobPercept> {
-		var events = new ArrayList<AuctionJobPercept>
+	public def getAuctionJobPercepts() : List<E_AuctionJobInfo> {
+		var events = new ArrayList<E_AuctionJobInfo>
 
 		for (jobId : auctionJobs.keySet) {
-			var ajp = new AuctionJobPercept(PlayerStates.keySet, auctionJobs.get(jobId));
+			var ajp = new E_AuctionJobInfo(players_team.keySet, auctionJobs.get(jobId));
 			events.add(ajp)
 		}
 		return events
@@ -374,40 +449,43 @@ class PerceptAggregator {
 	 * Function used to get all regular jobs
 	 * @returns a list of events each containing a regular job (Posted of opponent team).
 	 */
-	public def getRegularJobPercepts() : List<RegularJobPercept> {
-		var events = new ArrayList<RegularJobPercept>
+	public def getRegularJobPercepts() : List<E_RegularJobInfo> {
+		var events = new ArrayList<E_RegularJobInfo>
 
 		for (jobId : regularJobs.keySet) {
-			var rjp = new RegularJobPercept(PlayerStates.keySet, regularJobs.get(jobId));
+			var rjp = new E_RegularJobInfo(players_team.keySet, regularJobs.get(jobId));
 			events.add(rjp)
 		}
 		return events 
 	}
 
 	/** 
-	 * Function used to get all Mission Jobs
-	 * @returns a list of events each containing a mission event.
+	 * Build a set E_MissionJobInfo
+	 * To send information about all mission jobs known
+	 * 
+	 * @return an set of E_MissionJobInfo events 
 	 */
-	public def getMissionJobPercepts() : List<MissionJobPercept> {
-		var events = new ArrayList<MissionJobPercept>
+	public def getMissionJobPercepts() : List<E_MissionJobInfo> {
+		var events = new ArrayList<E_MissionJobInfo>
 
 		for (jobId : missionJobs.keySet) {
-			var mjp = new MissionJobPercept(PlayerStates.keySet, missionJobs.get(jobId));
+			var mjp = new E_MissionJobInfo(players_team.keySet, missionJobs.get(jobId));
 			events.add(mjp)
 		}
 		return events
 	}
 
-	
-	/**
-	 * Function used to get all team jobs
-	 * @returns a list of events each containing a team job.
+	/** 
+	 * Build a set E_TeamJobInfo
+	 * To send information about all team jobsknown
+	 * 
+	 * @return an set of E_TeamJobInfo events 
 	 */
-	public def getTeamJobPercepts() : List<TeamJobPercept> {
-		var events = new ArrayList<TeamJobPercept>
+	public def getTeamJobPercepts() : List<E_TeamJobInfo> {
+		var events = new ArrayList<E_TeamJobInfo>
 
 		for (jobId : teamJobs.keySet) {
-			var tjp = new TeamJobPercept(PlayerStates.keySet, teamJobs.get(jobId));
+			var tjp = new E_TeamJobInfo(players_team.keySet, teamJobs.get(jobId));
 			events.add(tjp)
 		}
 		return events 
@@ -417,22 +495,5 @@ class PerceptAggregator {
 	
 
 
-	/*
-	 * Methods to extract individual information from percepts
-	 */
-
-
-
-	/** 
-	 * Function used to get all storages
-	 * @returns a list of events containing storages
-	 */
-	public def getShopsNames() : Set<String> {
-		return shops.keySet()
-	}
-
-	public def getFacilitiesNames() : Set<String> {
-		return facilities.keySet()
-	}
 
 }

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/PerceptAggregator.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/aggregator/PerceptAggregator.sarl
@@ -59,6 +59,9 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.MissionJobPercept
 import java.util.List
 import java.util.Set
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.events.WorkshopSensedPercept
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.CityDataCreator
+import massim.protocol.scenario.city.data.FacilityData
+import massim.protocol.scenario.city.data.JobData
 
 /** 
  * @author boblo
@@ -71,8 +74,10 @@ class PerceptAggregator {
 	var missionJobs : HashMap<String, MissionJob>
 	public var chargingStations : HashMap<String, ChargingStation>
 	var dumps : HashMap<String, Dump>
+	var jobs : HashMap<String, JobData>
 	var regularJobs : HashMap<String, RegularJob>
 	var teamJobs : HashMap<String, TeamJob>
+	var facilities : HashMap<String, FacilityData>
 	var resources : HashMap<String, Resource>
 	var shops : HashMap<String, Shop>
 	var storages : HashMap<String, Storage>
@@ -134,77 +139,30 @@ class PerceptAggregator {
 	}
 	
 	/**
-	 * Function used to parse all of the percepts and populate the specialised Facilities. 
-	 * @param perepts - the collection of percepts received from MASSIM
+	 * Parse all of the percepts and populate the facilities hashmap with all facilities.
+	 * @param percepts - the collection of percepts received from MASSIM
 	 */
 	public def addFacilities(percepts : Collection<Percept>) {
-		for (p : percepts) {
-			switch (p.name) {
-				case "chargingStation": {
-					var cs = new ChargingStation(p)
-					this.chargingStations.put(cs.name, cs)
-				}
-				case "dump": {
-					var dp = new Dump(p)
-					this.dumps.put(dp.name, dp)
-				}
-				case "shop": {
-					var sp = new Shop(p)
-					this.shops.put(sp.name, sp)
-				}
-				case "storage": {
-					var st = new Storage(p)
-					this.storages.put(st.name, st)
-				}
-				case "workshop": {
-					var ws = new Workshop(p)
-					this.workshops.put(ws.name, ws)
-				}
-				case "resourceNode": {
-					var rn = new Resource(p)
-					this.resources.put(rn.name, rn)
-				}
-			}
-		}
+		percepts.stream().filter([ p : Percept |
+			CityDataCreator.FACILITY_TYPES.contains(p.name)
+		]).map([ p : Percept |
+			val facility = CityDataCreator.createFacility(p)
+			this.facilities.put(facility.name, facility)
+		]);
 	}
 
 
 	/**
-	 * Function used to populate the hashmaps keeping track of all of the jobs.
+	 * Parse all of the percepts and populate the jobs hashmap with all jobs (including Auction and Mission).
 	 * @param percepts - the collection of jobs
 	 */	
-	public def addJobs(percepts : Collection<Percept>){
-		for (p : percepts){
-			switch (p.name) {
-				case "job" : {
-					var storage = Util.extractString(p.parameters.get(1))
-					var storageFacility = this.storages.get(storage)
-					var rj = new RegularJob(p, storageFacility)
-					this.regularJobs.put(rj.id, rj)					
-				}
-				case "posted": {
-					var storage = Util.extractString(p.parameters.get(1))
-					var storageFacility = this.storages.get(storage)
-					var tj = new TeamJob(p, storageFacility)
-					this.teamJobs.put(tj.id, tj)
-					
-				}
-				case "auction": {
-					var storage = Util.extractString(p.parameters.get(1))
-					var storageFacility = this.storages.get(storage)
-					var aj = new AuctionJob(p, storageFacility)
-					this.auctionJobs.put(aj.id, aj)					
-				}
-				case "mission": {
-					var storage = Util.extractString(p.parameters.get(1))
-					var storageFacility = this.storages.get(storage)
-					var mj = new MissionJob(p, storageFacility)
-					this.missionJobs.put(mj.id, mj)
-				}
-			}
-		}
-		
-		
+	public def addJobs(percepts : Collection<Percept>) {
+		percepts.stream().filter([ p : Percept |
+			CityDataCreator.JOB_TYPES.contains(p.name)
+		]).map([ p : Percept |
+			val job = CityDataCreator.createJob(p)
+			this.jobs.put(job.getId(), job)
+		]);
 	}
 	
 	/**
@@ -474,8 +432,7 @@ class PerceptAggregator {
 	}
 
 	public def getFacilitiesNames() : Set<String> {
-		return shops.union(storages).union(chargingStations).union(dumps).union(workshops).
-			union(resources).keySet() 
+		return facilities.keySet()
 	}
 
 }

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/capacities/C_MassimTalking.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/capacities/C_MassimTalking.sarl
@@ -27,7 +27,7 @@ import eis.iilang.EnvironmentState
 import eis.iilang.Percept
 import eis.iilang.Action
 
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
 
 /** 
  * @author Sebastian Sardina (ssardina@gmail.com)
@@ -100,8 +100,8 @@ capacity C_MassimTalking {
 	/** 
 	 * Provides a map from player names to the player state
 	 */	
-	def MT_getAllPlayerStates() : Map<String, PlayerState>
-	def MT_getPlayerState(playerName : String) : PlayerState
+	def MT_getAllPlayerStates() : Map<String, TeamEntityAgent>
+	def MT_getPlayerState(playerName : String) : TeamEntityAgent
 
 
 	/*

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
@@ -53,7 +53,6 @@ import java.util.ArrayList
   * Responsible for the creation of java objects from eismassim Percept information provided by
   * the massim city server.
   */
-
 class CityDataCreator {
 
 	public static val FACILITY_TYPES = newHashSet(

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
@@ -1,0 +1,221 @@
+/**
+ * SARL-MASSIM - Interface between the SARL agent-oriented language
+ * and the MASSIM 2017 server
+ * Copyright (C) 2017 The SARL-MASSIM Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.edu.rmit.agtgrp.agtcity.sarl.mw.entities
+
+import java.util.HashMap
+import eis.iilang.ParameterList
+import eis.iilang.Function
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.Util
+import eis.iilang.Percept
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.SimStartBuffer
+
+import massim.protocol.scenario.city.data.FacilityData
+import massim.protocol.scenario.city.data.ChargingStationData
+import massim.protocol.scenario.city.data.DumpData
+import massim.protocol.scenario.city.data.ResourceNodeData
+
+import massim.protocol.scenario.city.data.ShopData
+import massim.protocol.scenario.city.data.StockData
+import massim.protocol.scenario.city.data.StoredData
+import massim.protocol.scenario.city.data.StorageData.TeamStoredData
+
+import massim.protocol.scenario.city.data.StorageData
+import massim.protocol.scenario.city.data.WellData
+import massim.protocol.scenario.city.data.WorkshopData
+
+import massim.protocol.scenario.city.data.ItemData
+
+import massim.protocol.scenario.city.data.JobData
+import massim.protocol.scenario.city.data.AuctionJobData
+import massim.protocol.scenario.city.data.MissionData
+import massim.protocol.scenario.city.data.ItemAmountData
+
+import java.util.List
+import java.util.ArrayList
+
+/**
+  * Shop describes an instance of a shop in the world
+  *
+  * Based on the support objects in massim provided {@link FacilityData} and others
+  *
+  * @param p the MASSIM Percept that is used to create the shop
+  */
+
+class CityDataCreator {
+
+	public static val FACILITY_TYPES = newHashSet(
+		"chargingStation",
+		"dump",
+		"shop",
+		"storage",
+		"workshop",
+		"resourceNode",
+		"well"
+	)
+
+	public static val JOB_TYPES = newHashSet(
+		"job",
+		"auction",
+		"mission"
+	)
+
+
+    /**
+     * Constructs a new Facility object.
+     */
+    static def createFacility(p : Percept) : FacilityData {
+		val name = Util.extractString(p.parameters.get(0))
+		val lat = Util.extractDouble(p.parameters.get(1))
+		val lon = Util.extractDouble(p.parameters.get(2))
+
+		switch (p.name) {
+			case "chargingStation": {
+				val rate = Util.extractInt(p.parameters.get(3))
+				return new ChargingStationData(name, lat, lon, rate);
+			}
+			case "dump": {
+				return new DumpData(name, lat, lon);
+			}
+			case "shop": {
+				val restock = Util.extractInt(p.parameters.get(3))
+				val items = p.parameters.get(4) as ParameterList
+				val stockData : List<StockData> = new ArrayList();
+				for (item : items) {
+					val f = item as Function
+					val itemName = Util.extractString(f.parameters.get(0))
+					// TODO: address SimStartBuffer stuff
+					val itemObj = SimStartBuffer.getItem(itemName)
+					val itemPrice = Util.extractInt(f.parameters.get(1))
+					val itemQty = Util.extractInt(f.parameters.get(2))
+					stockData.add(new StockData(itemName, itemPrice, itemQty))
+				}
+				return new ShopData(name, lat, lon, restock, stockData);
+			}
+			case "storage": {
+				val ^capacity = Util.extractInt(p.parameters.get(3))
+				val usedCapacity = Util.extractInt(p.parameters.get(4))
+				val stored : List<StoredData> = new ArrayList<StoredData>()
+				// TODO: will always be empty
+				val storedTeam : List<TeamStoredData> = null
+				val freeSpace = ^capacity - usedCapacity
+
+				val items = p.parameters.get(5) as ParameterList
+				for (item : items) {
+					val f = item as Function
+					val itemName = Util.extractString(f.parameters.get(0))
+					val itemStored = Util.extractInt(f.parameters.get(1))
+					val itemDelivered = Util.extractInt(f.parameters.get(2))
+					stored.add(new StoredData(itemName, itemStored, itemDelivered));
+				}
+
+				return new StorageData(name, lat, lon, ^capacity, freeSpace, stored, storedTeam);
+			}
+			case "workshop": {
+				return new WorkshopData(name, lat, lon)
+			}
+			case "resourceNode": {
+				val resource = Util.extractString(p.parameters.get(3))
+				return new ResourceNodeData(name, lat, lon, resource)
+			}
+			case "well": {
+				val team = Util.extractString(p.parameters.get(3))
+				val typeName = Util.extractString(p.parameters.get(4))
+				val integrity = Util.extractInt(p.parameters.get(5))
+				return new WellData(name, lat, lon, team, typeName, integrity)
+			}
+		}
+	}
+
+	static def createJob(p : Percept) : JobData {
+		val name = Util.extractString(p.parameters.get(0))
+		val storage = Util.extractString(p.parameters.get(1))
+		val start = Util.extractInt(p.parameters.get(3))
+		val end = Util.extractInt(p.parameters.get(4))
+		val reward = Util.extractInt(p.parameters.get(2))
+		val requiredItems = new ArrayList<ItemAmountData>()
+		// TODO: will always be empty
+		val deliveredItems = null
+
+		// The required items are always at the end of the structure as the last argument
+		var requireds = p.parameters.last as ParameterList
+
+		for (r : requireds) {
+			val required = r as Function
+			val requiredItemName = Util.extractString(required.parameters.get(0))
+			val requiredQty = Util.extractInt(required.parameters.get(1))
+			// TODO: address SimStartBuffer stuff
+			val itemVolume = SimStartBuffer.getItem(requiredItemName).volume
+			requiredItems.add(new ItemAmountData(requiredItemName, requiredQty))
+		}
+
+		switch (p.name) {
+			case "job" : {
+				return new JobData(name,
+					storage,
+					start,
+					end,
+					reward,
+					requiredItems,
+					deliveredItems,
+					JobData.POSTER_SYSTEM
+				);
+			}
+			case "auction": {
+				val fine = Util.extractInt(p.parameters.get(5))
+				val lowestBid = Util.extractInt(p.parameters.get(6))
+				val auctionTime = Util.extractInt(p.parameters.get(7))
+
+				return new AuctionJobData(name,
+					storage,
+					start,
+					end,
+					reward,
+					requiredItems,
+					fine,
+					lowestBid,
+					auctionTime,
+					deliveredItems,
+					null // no poster provided
+				)
+			}
+			case "mission": {
+				val fine = Util.extractInt(p.parameters.get(5))
+				val lowestBid = Util.extractInt(p.parameters.get(6))
+				val auctionTime = Util.extractInt(p.parameters.get(7))
+				return new MissionData(name,
+					storage,
+					start,
+					end,
+					reward,
+					requiredItems,
+					fine,
+					lowestBid,
+					auctionTime,
+					deliveredItems,
+					null, // no mission poster provided
+					null // no mission ID provided
+				)
+			}
+		}
+	}
+    def getShopItems(): HashMap<String, ShopItem>{
+    	return shopItems
+    }
+
+}

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/CityDataCreator.sarl
@@ -50,11 +50,8 @@ import java.util.List
 import java.util.ArrayList
 
 /**
-  * Shop describes an instance of a shop in the world
-  *
-  * Based on the support objects in massim provided {@link FacilityData} and others
-  *
-  * @param p the MASSIM Percept that is used to create the shop
+  * Responsible for the creation of java objects from eismassim Percept information provided by
+  * the massim city server.
   */
 
 class CityDataCreator {
@@ -74,7 +71,6 @@ class CityDataCreator {
 		"auction",
 		"mission"
 	)
-
 
     /**
      * Constructs a new Facility object.
@@ -142,6 +138,9 @@ class CityDataCreator {
 		}
 	}
 
+    /**
+     * Constructs a new Job object.
+     */
 	static def createJob(p : Percept) : JobData {
 		val name = Util.extractString(p.parameters.get(0))
 		val storage = Util.extractString(p.parameters.get(1))
@@ -214,8 +213,4 @@ class CityDataCreator {
 			}
 		}
 	}
-    def getShopItems(): HashMap<String, ShopItem>{
-    	return shopItems
-    }
-
 }

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/GameEntity.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/GameEntity.sarl
@@ -21,7 +21,7 @@ package au.edu.rmit.agtgrp.agtcity.sarl.mw.entities
  * @author boblo
  * 
  */
-class GameEntity extends Position {
+class EntityAgent extends Position {
 	public var name : String
 	public var role : String
 	public var team : String

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/PlayerState.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/entities/PlayerState.sarl
@@ -18,27 +18,24 @@
  */
  package au.edu.rmit.agtgrp.agtcity.sarl.mw.entities
 
-import java.util.HashMap
-
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.EntityBuffer
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.PositionBuilder
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.TeamBuffer
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.Util
 import eis.iilang.Function
 import eis.iilang.ParameterList
 import eis.iilang.Percept
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Position
 import java.util.Collection
 import java.util.HashMap
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Facility
-
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.aggregator.*
-
-import java.util.*
+import java.util.Vector
 
 /** 
  * @author bob
  * @author Sebastian Sardina (ssardina@gmail.com)
  * 
- * A class to store a player state in the simulation
+ * A class to store a player state in the simulation (e.g., its location, current route, charge level, etc)
  */
-class PlayerState extends GameEntity {
+class TeamEntityAgent extends EntityAgent {
 
     public var charge : double      
     public var load : double

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_AgentPercept.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_AgentPercept.sarl
@@ -22,26 +22,26 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.AuctionJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ChargingStation
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Dump
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Facility
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.GameEntity
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ItemContainer
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Job
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.RegularJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Resource
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Shop
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Storage
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Workshop
 import java.util.HashSet
 import java.util.Set
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.MissionJob
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.ActionResult
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.EntityAgent
 
 /** 
  * E_AgentPercept superclass used to pass on all percepts from MASSIM. 
  * @param sources : a set of originating agents for a given percept 
  */
-event E_AgentPercept {
+event E_AgentInfo {
 	var sources : Set<String>	// the source of the percept
 
 	new(sources : Set<String>) {
@@ -54,7 +54,7 @@ event E_AgentPercept {
  * TeamPercept emitted once per tick to notify all entities of current team status. 
  * @param monty, current team money. 
  */
-event TeamPercept extends E_AgentPercept {
+event E_TeamInfo extends E_AgentInfo {
 	var money : double
 
 	new(sources : Set<String>, money : double) {
@@ -68,7 +68,7 @@ event TeamPercept extends E_AgentPercept {
  * ActionStatusPercept emitted once per tick to notify an agent of it's action result from the previous tick. 
  * @param actionResult, object containing data relating to the previous action and it's result. 
  */
-event ActionStatusPercept extends E_AgentPercept { 
+event E_ActionStatusInfo extends E_AgentInfo { 
 	var actionResult : ActionResult
 
 	new(sources : Set<String>, actionResultt : ActionResult) {

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_EntityPercept.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_EntityPercept.sarl
@@ -18,20 +18,20 @@
  */
 package au.edu.rmit.agtgrp.agtcity.sarl.mw.events
 
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.GameEntity
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
 import java.util.HashSet
 import java.util.Set
-
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.EntityAgent
 
 /** 
- * EntityPercept emitted once per tick per observed entity. 
- * @param entity, the observed entity. 
+ * An event to transmit a GameEntity object. An entity is a game player, team-mate or opponent.
+ * 
+ * @param entity, the observed entity (team-mate or opponent). 
  */
-event EntityPercept extends E_AgentPercept {
-	var entity : GameEntity	// the game entity containing the percept data
+event E_TellEntityInfo extends E_AgentInfo {
+	var entity : EntityAgent	// the game entity containing the percept data
 
-	new(source : Set<String>, entity : GameEntity) {
+	new(source : Set<String>, entity : EntityAgent) {
 		super(source);
 		this.entity = entity;
 
@@ -43,11 +43,11 @@ event EntityPercept extends E_AgentPercept {
  * TeamMemberPercept emitted once per tick per observed teammate. 
  * @param PlayerState, the observed entity. 
  */
-event TeamMemberPercept extends EntityPercept {
+event E_TellPlayerTeamInfo extends E_TellEntityInfo {
 
-	var PlayerState : PlayerState
+	var PlayerState : TeamEntityAgent
 
-	new(sources : HashSet<String>, PlayerState : PlayerState) {
+	new(sources : HashSet<String>, PlayerState : TeamEntityAgent) {
 		super(sources, PlayerState)
 		this.PlayerState = PlayerState
 	}

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_FacilityPercept.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_FacilityPercept.sarl
@@ -29,11 +29,11 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.Workshop
 import java.util.Set
 
 /** 
- * FacilitySensedPercept emitted once for every facility that was observed each tick. If multiple agents observe the same facility, only 1 is emitted. 
- * This is also the super class for all percepts of specific facilities. 
- * @param facility - the facility that was observed.
+ * Emitted to distribute information about a facility 
+ * 
+ * @param facility - the facility to be distributed
  */
-event FacilitySensedPercept extends E_AgentPercept {
+event E_FacilityInfo extends E_AgentInfo {
 	var facility : Facility
 
 	new(sources : Set<String>, facility : Facility) {
@@ -43,11 +43,12 @@ event FacilitySensedPercept extends E_AgentPercept {
 }
 
 
-/**
- * Inherited from FacilitySensedPercept, emitted once for every shop that was observed each tick. 
- * @param shop The shop object
+/** 
+ * Emitted to distribute information about a shop
+ * 
+ * @param shop  - the shop to be distributed
  */
-event ShopSensedPercept extends FacilitySensedPercept {
+event E_ShopInfo extends E_FacilityInfo {
 	var shop : Shop
 
 	new(sources : Set<String>, shop : Shop) {
@@ -56,23 +57,13 @@ event ShopSensedPercept extends FacilitySensedPercept {
 	}
 }
 
-/** 
- * currently not implemented
- */
-event ShopUpdatePercept extends ShopSensedPercept {
-	var items : ItemContainer
-
-	new(sources : Set<String>, shop : Shop, items : ItemContainer) {
-		super(sources, shop)
-		this.items = items;
-	}
-}
 
 /** 
- * WorkshopSensedPercept, emitted once per tick for every observed workshop.
- * @param workshop - The workshop entity that was observed.
+ * Emitted to distribute information about a workshop
+ * 
+ * @param workshop - The workshop entity to be distributed
  */
-event WorkshopSensedPercept extends FacilitySensedPercept {
+event E_WorkshopInfo extends E_FacilityInfo {
 	var workshop : Workshop
 
 	new(sources : Set<String>, workshop : Workshop) {
@@ -82,10 +73,11 @@ event WorkshopSensedPercept extends FacilitySensedPercept {
 }
 
 /** 
- * ChargingStationPercept, emitted once per tick for every observed charging station.
- * @param chargingStation- The charging entity that was observed.
+ * Emitted to distribute information about a charging stations
+ * 
+ * @param chargingStation The charging entity that was observed.
  */
-event ChargingStationSensedPercept extends FacilitySensedPercept {
+event E_ChargingStationInfo extends E_FacilityInfo {
 	var chargingStation : ChargingStation
 
 	new(sources : Set<String>, chargingStation : ChargingStation) {
@@ -95,10 +87,11 @@ event ChargingStationSensedPercept extends FacilitySensedPercept {
 }
 
 /** 
- * DumpSensedPercept, emitted once per tick for every observed dump.
- * @param dump - The dump entity that was observed.
+ * Emitted to distribute information about a dumps
+ * 
+ * @param dump - The dump entity to be distributed.
  */
-event DumpSensedPercept extends FacilitySensedPercept {
+event E_DumpInfo extends E_FacilityInfo {
 	var dump : Dump
 
 	new(sources : Set<String>, dump : Dump) {
@@ -107,10 +100,11 @@ event DumpSensedPercept extends FacilitySensedPercept {
 	}
 }
 /** 
- * StorageSensedPercept, emitted once per tick for every observed storage.
- * @param storage - The storage entity that was observed.
+ * Emitted to distribute information about a storage
+ * 
+ * @param storage - The storage entity to be distributed
  */
-event StorageSensedPercept extends FacilitySensedPercept {
+event E_StorageInfo extends E_FacilityInfo {
 	var storage : Storage
 
 	new(sources : Set<String>, storage : Storage) {
@@ -119,17 +113,36 @@ event StorageSensedPercept extends FacilitySensedPercept {
 	}
 }
 
+
+
+
+
+
+/** 
+ * currently not implemented
+ */
+event ShopUpdatePercept extends E_ShopInfo {
+	var items : ItemContainer
+
+	new(sources : Set<String>, shop : Shop, items : ItemContainer) {
+		super(sources, shop)
+		this.items = items;
+	}
+}
+
+
+
 /** 
  * NOT IMPLEMENTED, 
  */
-event StorageUsedUpdatedPercept extends FacilitySensedPercept {
+event StorageUsedUpdatedPercept extends E_FacilityInfo {
 	// TODO COMPLETE ME> update the storage used if the other team has dropped or collected things
 }
 
 /** 
  * NOT IMPLEMENTED
  */
-event StorageItemStoredPercept extends FacilitySensedPercept {
+event StorageItemStoredPercept extends E_FacilityInfo {
 	var items : ItemContainer
 
 	new(sources : Set<String>, storage : Storage, items : ItemContainer) {
@@ -141,7 +154,7 @@ event StorageItemStoredPercept extends FacilitySensedPercept {
 /** 
  * NOT IMPLEMENTED
  */
-event StorageDeliveredUpdatedPercept extends FacilitySensedPercept {
+event StorageDeliveredUpdatedPercept extends E_FacilityInfo {
 	var items : ItemContainer
 
 	new(sources : Set<String>, storage : Storage, items : ItemContainer) {
@@ -154,7 +167,7 @@ event StorageDeliveredUpdatedPercept extends FacilitySensedPercept {
  * ResourceSensedPercept emitted once per resource per tick
  * @param resouce - The resource patch that was observed.
  */
-event ResourceSensedPercept extends FacilitySensedPercept {
+event E_ResourceInfo extends E_FacilityInfo {
 	var resource : Resource
 
 	new(sources : Set<String>, resource : Resource) {

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_JobPercept.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/events/E_JobPercept.sarl
@@ -30,7 +30,7 @@ import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.MissionJob
  * JobPercept, emitted once per tick for every observed job. Superclass to all jobs
  * @param job - The job entity that was observed.
  */
-event JobPercept extends E_AgentPercept {
+event E_JobInfo extends E_AgentInfo {
 	var job : Job
 
 	new(sources : Set<String>, job : Job) {
@@ -43,7 +43,7 @@ event JobPercept extends E_AgentPercept {
  * RegularJob, emitted once per tick for every observed Regular Job, inherited from Job.
  * @param regularJob - The RegularJob entity that was observed.
  */
-event RegularJobPercept extends JobPercept {
+event E_RegularJobInfo extends E_JobInfo {
 	var regularJob : RegularJob
 
 	new(sources : Set<String>, job : RegularJob) {
@@ -56,7 +56,7 @@ event RegularJobPercept extends JobPercept {
  * TeamJobPercept, emitted once per tick for every observed job posted by a team member..
  * @param teamJob - The teamJob entity that was observed.
  */
-event TeamJobPercept extends JobPercept {
+event E_TeamJobInfo extends E_JobInfo {
 	var teamJob : TeamJob
 
 	new(sources : Set<String>, job : TeamJob) {
@@ -69,7 +69,7 @@ event TeamJobPercept extends JobPercept {
  * ActionJobPercept, emitted once per tick for every observed Auction.
  * @param auctionJob - The auction job entity that was observed.
  */
-event AuctionJobPercept extends JobPercept {
+event E_AuctionJobInfo extends E_JobInfo {
 	var auctionJob : AuctionJob
 
 	new(sources : Set<String>, job : AuctionJob) {
@@ -83,7 +83,7 @@ event AuctionJobPercept extends JobPercept {
  * MissionJobPercept, emitted once per tick for every observed mission posting.
  * @param missionJob - The MissionJob entity that was observed.
  */
-event MissionJobPercept extends JobPercept {
+event E_MissionJobInfo extends E_JobInfo {
 	var missionJob : MissionJob 
 
 	new(sources : Set<String>, missionJob : MissionJob) {

--- a/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/skills/S_MassimTalking.sarl
+++ b/src/main/sarl/au/edu/rmit/agtgrp/agtcity/sarl/mw/skills/S_MassimTalking.sarl
@@ -40,13 +40,13 @@ import eis.iilang.Action
 import io.sarl.core.Logging
 
 import au.edu.rmit.agtgrp.agtcity.sarl.mw.capacities.C_MassimTalking
-import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.PlayerState
 import eis.exceptions.ActException
 import java.util.HashSet
 import java.nio.file.Paths
 import org.json.JSONArray
 import java.io.File
 import java.io.FileWriter
+import au.edu.rmit.agtgrp.agtcity.sarl.mw.entities.TeamEntityAgent
 
 /** 
  * @author Sebastian Sardina (ssardina@gmail.com)
@@ -94,7 +94,7 @@ skill S_MassimTalking implements C_MassimTalking {
 	 * (for all that have been authenticated in the game server)
 	 * 
 	 */
-	var players : Map<String, PlayerState> = new HashMap<String, PlayerState>()
+	var players : Map<String, TeamEntityAgent> = new HashMap<String, TeamEntityAgent>()
 
 	/*
 	 * Stores all the players in the game server that I will connect and control
@@ -285,7 +285,7 @@ skill S_MassimTalking implements C_MassimTalking {
 		// the ei system register the agent
 		if (ei.getAssociatedEntities(playerName).contains(playerEntity)) {
 			debug("Agent *{0}* has been successfully associated with entity *{1}*", playerName, playerEntity)
-			this.players.put(playerName, new PlayerState(playerName, playerClass, playerTeam))
+			this.players.put(playerName, new TeamEntityAgent(playerName, playerClass, playerTeam))
 		} else {
 			warning("Unsuccessful association of agent *{0}* with entity *{1}*", playerName, playerEntity)
 		}
@@ -346,10 +346,10 @@ skill S_MassimTalking implements C_MassimTalking {
 	/** 
 	 * Provides a map from player names to the player state
 	 */	
-	def MT_getAllPlayerStates() : Map<String, PlayerState> {
+	def MT_getAllPlayerStates() : Map<String, TeamEntityAgent> {
 		return players
 	}
-	def MT_getPlayerState(playerName : String) : PlayerState {
+	def MT_getPlayerState(playerName : String) : TeamEntityAgent {
 		return players.get(playerName)
 	}
 


### PR DESCRIPTION
A start at un-tangling our home-made entity classes from the aggregator, and using those conveniently provided by the massim protocol package.

Still to do:
- Remove all entity type specific data-structures (eg shops, resourceNodes) and
    operate over the more generic collections (eg facilities, jobs) by filtering
    by class type or name
- Remove home-made entities completely.